### PR TITLE
Replaces deprecated np.int dtype with Python-native int dtype

### DIFF
--- a/vugrad/functions.py
+++ b/vugrad/functions.py
@@ -29,7 +29,7 @@ def load_synth(num_train=60_000, num_val=10_000):
 
     # compute the quadratic form
     q = np.einsum('bf, fk, bk -> b', x, quad, x)
-    y = (q > THRESHOLD).astype(np.int)
+    y = (q > THRESHOLD).astype(int)
 
     return (x[:num_train, :], y[:num_train]), (x[num_train:, :], y[num_train:]), 2
 


### PR DESCRIPTION
This pull request updates the load_synth function to use Python's native integer type instead of np.int, which has been [deprecated since Numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html) 

The change ensures compatibility with future versions of NumPy by replacing the `np.int` type casting to Python's native integer type, which is functionally identical as `np.int` was simply an alias to the native type prior to its deprecation. 